### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run the script without making any changes. Default `false`.
   with:
       owner-type: org # or user
       token: ${{ secrets.PAT_TOKEN }}
-      repository_owner: ${{ github.repository_owner }}
+      repository-owner: ${{ github.repository_owner }}
       delete-untagged: true
 ```
 
@@ -74,7 +74,7 @@ Run the script without making any changes. Default `false`.
   with:
       owner-type: org # or user
       token: ${{ secrets.PAT_TOKEN }}
-      repository_owner: ${{ github.repository_owner }}
+      repository-owner: ${{ github.repository_owner }}
       package-name: test-image
       delete-untagged: true
 ```
@@ -85,7 +85,7 @@ Run the script without making any changes. Default `false`.
   with:
     owner-type: org # or user
     token: ${{ secrets.PAT_TOKEN }}
-    repository_owner: ${{ github.repository_owner }}
+    repository-owner: ${{ github.repository_owner }}
     repository-name: ${{ github.repository }}
     delete-untagged: false
     keep-at-most: 5
@@ -97,7 +97,7 @@ Run the script without making any changes. Default `false`.
   with:
       owner-type: org # or user
       token: ${{ secrets.PAT_TOKEN }}
-      repository_owner: ${{ github.repository_owner }}
+      repository-owner: ${{ github.repository_owner }}
       package-name: test-image
       delete-untagged: true
       keep-at-most: 5


### PR DESCRIPTION
Correct the code examples by replacing `repository_owner` with `repository-owner`.

I received this warning on runs:

> Warning: Unexpected input(s) 'repository_owner', valid inputs are ['token', 'repository-owner', 'repository-name', 'package-name', 'owner-type', 'delete-untagged', 'keep-at-most', 'filter-tags', 'skip-tags', 'dry-run']

While it still worked, the code examples used `repository_owner`, the documentation in the readme is correct.